### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Ayame
 Ayame is a component based WSGI framework. It is inspired by
 `Apache Wicket`_, `Apache Click`_ and Flask_.
 
-.. image:: https://pypip.in/version/ayame/badge.svg
+.. image:: https://img.shields.io/pypi/v/ayame.svg
    :target: https://pypi.python.org/pypi/ayame
 
 .. image:: https://drone.io/github.com/hattya/ayame/status.png


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ayame))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ayame`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.